### PR TITLE
DW-4064 Add container logging to OS created user containers

### DIFF
--- a/src/main/kotlin/uk/gov/dwp/dataworks/aws/AwsCommunicator.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/aws/AwsCommunicator.kt
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
 import software.amazon.awssdk.services.ecs.model.AwsVpcConfiguration
 import software.amazon.awssdk.services.ecs.model.ContainerDefinition
-import software.amazon.awssdk.services.ecs.model.LogConfiguration
 import software.amazon.awssdk.services.ecs.model.CreateServiceRequest
 import software.amazon.awssdk.services.ecs.model.DeleteServiceRequest
 import software.amazon.awssdk.services.ecs.model.NetworkConfiguration

--- a/src/main/kotlin/uk/gov/dwp/dataworks/aws/AwsCommunicator.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/aws/AwsCommunicator.kt
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
 import software.amazon.awssdk.services.ecs.model.AwsVpcConfiguration
 import software.amazon.awssdk.services.ecs.model.ContainerDefinition
+import software.amazon.awssdk.services.ecs.model.LogConfiguration
 import software.amazon.awssdk.services.ecs.model.CreateServiceRequest
 import software.amazon.awssdk.services.ecs.model.DeleteServiceRequest
 import software.amazon.awssdk.services.ecs.model.NetworkConfiguration

--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/ConfigurationResolver.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/ConfigurationResolver.kt
@@ -70,5 +70,9 @@ enum class ConfigKey(val key: String, val isList: Boolean) {
     USER_TASK_VPC_SECURITY_GROUPS("orchestrationService.user_task_security_groups", true),
     USER_TASK_VPC_SUBNETS("orchestrationService.user_task_subnets", true),
     ECR_ENDPOINT("orchestrationService.ecr_endpoint", false),
+<<<<<<< HEAD
     AWS_ACCOUNT_NUMBER("orchestrationService.aws_account_number", false)
+=======
+    CONTAINER_LOG_GROUP("orchestrationService.container_log_group", false)
+>>>>>>> DW-4064 Add container logging to OS created user containers
 }

--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/ConfigurationResolver.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/ConfigurationResolver.kt
@@ -70,9 +70,6 @@ enum class ConfigKey(val key: String, val isList: Boolean) {
     USER_TASK_VPC_SECURITY_GROUPS("orchestrationService.user_task_security_groups", true),
     USER_TASK_VPC_SUBNETS("orchestrationService.user_task_subnets", true),
     ECR_ENDPOINT("orchestrationService.ecr_endpoint", false),
-<<<<<<< HEAD
     AWS_ACCOUNT_NUMBER("orchestrationService.aws_account_number", false)
-=======
     CONTAINER_LOG_GROUP("orchestrationService.container_log_group", false)
->>>>>>> DW-4064 Add container logging to OS created user containers
 }

--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/ConfigurationResolver.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/ConfigurationResolver.kt
@@ -70,6 +70,6 @@ enum class ConfigKey(val key: String, val isList: Boolean) {
     USER_TASK_VPC_SECURITY_GROUPS("orchestrationService.user_task_security_groups", true),
     USER_TASK_VPC_SUBNETS("orchestrationService.user_task_subnets", true),
     ECR_ENDPOINT("orchestrationService.ecr_endpoint", false),
-    AWS_ACCOUNT_NUMBER("orchestrationService.aws_account_number", false)
+    AWS_ACCOUNT_NUMBER("orchestrationService.aws_account_number", false),
     CONTAINER_LOG_GROUP("orchestrationService.container_log_group", false)
 }

--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.ecs.model.KeyValuePair
 import software.amazon.awssdk.services.ecs.model.LoadBalancer
 import software.amazon.awssdk.services.ecs.model.NetworkMode
 import software.amazon.awssdk.services.ecs.model.PortMapping
+import software.amazon.awssdk.services.ecs.model.LogConfiguration
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetTypeEnum
 import software.amazon.awssdk.services.iam.model.Policy
 import uk.gov.dwp.dataworks.aws.AwsCommunicator

--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
@@ -111,8 +111,9 @@ class TaskDeploymentService {
                         "awslogs-group" to configurationResolver.getStringConfig(ConfigKey.CONTAINER_LOG_GROUP), 
                         "awslogs-region" to configurationResolver.getStringConfig(ConfigKey.AWS_REGION),
                         "awslogs-stream-prefix" to userName + "_jupyterhub"
-                    )
-                    .build())
+                    ))
+                    .build()
+                )
                 .build()
 
         val headlessChrome = ContainerDefinition.builder()
@@ -148,8 +149,9 @@ class TaskDeploymentService {
                         "awslogs-group" to configurationResolver.getStringConfig(ConfigKey.CONTAINER_LOG_GROUP), 
                         "awslogs-region" to configurationResolver.getStringConfig(ConfigKey.AWS_REGION),
                         "awslogs-stream-prefix" to userName + "_headlessChrome"
-                    )
-                    .build())
+                    ))
+                    .build()
+                )
                 .build()
 
         val guacd = ContainerDefinition.builder()
@@ -165,8 +167,9 @@ class TaskDeploymentService {
                         "awslogs-group" to configurationResolver.getStringConfig(ConfigKey.CONTAINER_LOG_GROUP), 
                         "awslogs-region" to configurationResolver.getStringConfig(ConfigKey.AWS_REGION),
                         "awslogs-stream-prefix" to userName + "_guacd"
-                    )
-                    .build())
+                    ))
+                    .build()
+                )
                 .build()
 
         val guacamole = ContainerDefinition.builder()
@@ -190,8 +193,9 @@ class TaskDeploymentService {
                         "awslogs-group" to configurationResolver.getStringConfig(ConfigKey.CONTAINER_LOG_GROUP), 
                         "awslogs-region" to configurationResolver.getStringConfig(ConfigKey.AWS_REGION),
                         "awslogs-stream-prefix" to userName + "_guacamole"
-                    )
-                    .build())
+                    ))
+                    .build()
+                )
                 .build()
 
         return listOf(jupyterHub, headlessChrome, guacd, guacamole)

--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
@@ -94,13 +94,13 @@ class TaskDeploymentService {
         }
     }
 
-    private fun buildLogConfiguration(userName: String, containerName: String) {
-        var logConfig = LogConfiguration.builder()                
+    private fun buildLogConfiguration(userName: String, containerName: String): LogConfiguration {
+        val logConfig = LogConfiguration.builder()
             .logDriver("awslogs")
             .options(mapOf(
                 "awslogs-group" to configurationResolver.getStringConfig(ConfigKey.CONTAINER_LOG_GROUP), 
                 "awslogs-region" to configurationResolver.getStringConfig(ConfigKey.AWS_REGION),
-                "awslogs-stream-prefix" to userName + "_" + containerName
+                "awslogs-stream-prefix" to "${userName}_${containerName}"
             ))
             .build()
         return logConfig
@@ -110,8 +110,6 @@ class TaskDeploymentService {
         val ecrEndpoint = configurationResolver.getStringConfig(ConfigKey.ECR_ENDPOINT)
         val screenSize = 1920 to 1080
         
-        
-
         val jupyterHub = ContainerDefinition.builder()
                 .name("jupyterHub")
                 .image("$ecrEndpoint/aws-analytical-env/jupyterhub")

--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -112,6 +112,10 @@ module "ecs-fargate-task-definition" {
         "elasticloadbalancing.${var.region}.amazonaws.com",
         "ecs.${var.region}.amazonaws.com"
       ])
+    },
+    {
+      name  = "orchestrationService.container_log_group"
+      value = module.ecs-user-host.outputs.user_container_log_group
     }
   ]
 }

--- a/terraform/modules/ecs-user/cloudwatch.tf
+++ b/terraform/modules/ecs-user/cloudwatch.tf
@@ -1,0 +1,8 @@
+#
+## ---------------------------------------------------------------------------------------------------------------------
+## Analytical UI Container Log Group
+## ---------------------------------------------------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "user_container_log_group" {
+  name = "/aws/ecs/${var.name_prefix}/user-container-logs/"
+  tags = var.common_tags
+}

--- a/terraform/modules/ecs-user/outputs.tf
+++ b/terraform/modules/ecs-user/outputs.tf
@@ -1,6 +1,7 @@
 output "outputs" {
   value = {
-    ecs_cluster       = aws_ecs_cluster.user_host
-    security_group_id = aws_security_group.user_host.id
+    ecs_cluster              = aws_ecs_cluster.user_host
+    security_group_id        = aws_security_group.user_host.id
+    user_container_log_group = aws_cloudwatch_log_group.user_container_log_group.name
   }
 }


### PR DESCRIPTION
Current tasks deployed by the orchestration service do not have any log configuration, this needs to be rectified.

* Add awslogs driver to the containers created by Orchestration Service
* Write terraform to create log-group