### PR TITLE
DW-4056 - Migrating to new service state file reference

### DIFF
--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -89,7 +89,7 @@ module "ecs-fargate-task-definition" {
     },
     {
       name  = "PROXY_HOST"
-      value = data.terraform_remote_state.emr_cluster_broker_infra.outputs.vpc.internet_proxy_vpce.dns_name
+      value = data.terraform_remote_state.analytical_service_infra.outputs.vpc.internet_proxy_vpce.dns_name
     },
     {
       name = "NON_PROXY_HOSTS"
@@ -127,8 +127,8 @@ module "ecs-fargate-service" {
   source          = "../../modules/fargate-service"
   name_prefix     = var.name_prefix
   region          = var.region
-  vpc_id          = data.terraform_remote_state.emr_cluster_broker_infra.outputs.vpc.aws_vpc.id
-  private_subnets = data.terraform_remote_state.emr_cluster_broker_infra.outputs.vpc.aws_subnets_private.*.id
+  vpc_id          = data.terraform_remote_state.analytical_service_infra.outputs.vpc.aws_vpc.id
+  private_subnets = data.terraform_remote_state.analytical_service_infra.outputs.vpc.aws_subnets_private.*.id
 
   ecs_cluster_name        = data.aws_ecs_cluster.ecs_main_cluster.cluster_name
   ecs_cluster_arn         = data.aws_ecs_cluster.ecs_main_cluster.arn
@@ -142,14 +142,14 @@ module "ecs-fargate-service" {
   role_arn = {
     management-dns = "arn:aws:iam::${local.account[local.management_account[local.environment]]}:role/${var.assume_role}"
   }
-  interface_vpce_sg_id      = data.terraform_remote_state.emr_cluster_broker_infra.outputs.interface_vpce_sg_id
-  s3_prefixlist_id          = data.terraform_remote_state.emr_cluster_broker_infra.outputs.s3_prefix_list_id
-  dynamodb_prefixlist_id    = data.terraform_remote_state.emr_cluster_broker_infra.outputs.dynamodb_prefix_list_id
+  interface_vpce_sg_id      = data.terraform_remote_state.analytical_service_infra.outputs.interface_vpce_sg_id
+  s3_prefixlist_id          = data.terraform_remote_state.analytical_service_infra.outputs.s3_prefix_list_id
+  dynamodb_prefixlist_id    = data.terraform_remote_state.analytical_service_infra.outputs.dynamodb_prefix_list_id
   common_tags               = local.common_tags
   parent_domain_name        = local.parent_domain_name[local.environment]
   root_dns_prefix           = local.root_dns_prefix[local.environment]
   cert_authority_arn        = data.terraform_remote_state.aws_certificate_authority.outputs.root_ca.arn
-  internet_proxy_vpce_sg_id = data.terraform_remote_state.emr_cluster_broker_infra.outputs.vpc.internet_proxy_vpce.sg_id
+  internet_proxy_vpce_sg_id = data.terraform_remote_state.analytical_service_infra.outputs.vpc.internet_proxy_vpce.sg_id
 }
 
 data "aws_ami" "hardened" {

--- a/terraform/deploy/app/terraform.tf.j2
+++ b/terraform/deploy/app/terraform.tf.j2
@@ -11,13 +11,13 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "emr_cluster_broker_infra" {
+data "terraform_remote_state" "analytical_service_infra" {
   backend = "s3"
   workspace = terraform.workspace
 
   config = {
     bucket         = "{{state_file_bucket}}"
-    key            = "terraform/dataworks/emr-cluster-broker-infra.tfstate"
+    key            = "terraform/dataworks/analytical-service-infra.tfstate"
     region         = "{{state_file_region}}"
     encrypt        = true
     kms_key_id     = "arn:aws:kms:{{state_file_region}}:{{state_file_account}}:key/{{state_file_kms_key}}"


### PR DESCRIPTION
This should only be merged once [the infra migration](https://github.com/dwp/dataworks-analytical-service-infra/pull/2) has been merged and run to create the new state file. If merged before this then TF will fail to find the new state.