### PR TITLE
[DW-4185] Add cloudwatch metric filters and alarms

### DIFF
--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -228,12 +228,13 @@ module "cleanup_lambda" {
 ## ---------------------------------------------------------------------------------------------------------------------
 
 module "orchestration_service_failed_to_destroy_alarm" {
-  source = "dwp/metric-filter-alarm/aws"
+  source  = "dwp/metric-filter-alarm/aws"
+  version = "1.1.5"
 
   log_group_name      = module.ecs-fargate-task-definition.log_group
   metric_namespace    = "/app/${var.name_prefix}"
   pattern             = "{ $.message = \"Failed to destroy*\"}"
-  alarm_name          = "FailedToDestroy"
+  alarm_name          = "Orchestration Service Failed To Destroy Resources"
   alarm_action_arns   = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   evaluation_periods  = "1"
   period              = 60
@@ -243,15 +244,15 @@ module "orchestration_service_failed_to_destroy_alarm" {
 }
 
 module "guacamole_invalid_user_desktop_alarm" {
-  source = "dwp/metric-filter-alarm/aws"
+  source  = "dwp/metric-filter-alarm/aws"
+  version = "1.1.5"
 
   log_group_name   = module.ecs-user-host.outputs.user_container_log_group
   metric_namespace = "/app/${var.name_prefix}-user-host-guacamole"
-  pattern          = "Cognito user tried to access desktop for"
   # No consistent JSON logging for these container_logs, so pattern is plaintext search
-  alarm_name = "InvalidUserDesktopAccess"
-  alarm_action_arns = [
-  data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
+  pattern             = "Cognito user tried to access desktop for"
+  alarm_name          = "Cognito user tried to access another desktop"
+  alarm_action_arns   = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   evaluation_periods  = "1"
   period              = 60
   threshold           = 0

--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -227,7 +227,7 @@ module "cleanup_lambda" {
 ## Cloudwatch Log Metrics/Alarms
 ## ---------------------------------------------------------------------------------------------------------------------
 
-module "failed_to_destroy_alarm" {
+module "orchestration_service_failed_to_destroy_alarm" {
   source = "dwp/metric-filter-alarm/aws"
 
   log_group_name    = module.ecs-fargate-task-definition.log_group
@@ -235,22 +235,26 @@ module "failed_to_destroy_alarm" {
   pattern           = "{ $.message = \"Failed to destroy*\"}"
   alarm_name        = "FailedToDestroy"
   alarm_action_arns = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
-  period            = "60"
-  threshold         = "0"
-  statistic         = "Sum"
+  evaluation_periods  = "1"
+  period              = 60
+  threshold           = 0
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
 }
 
-module "invalid_user_desktop_alarm" {
+module "guacamole_invalid_user_desktop_alarm" {
   source = "dwp/metric-filter-alarm/aws"
 
   log_group_name   = module.ecs-user-host.outputs.user_container_log_group
-  metric_namespace = "/app/guacamole"
+  metric_namespace = "/app/${var.name_prefix}-user-host-guacamole"
   pattern          = "Cognito user tried to access desktop for"
   # No consistent JSON logging for these container_logs, so pattern is plaintext search
   alarm_name = "InvalidUserDesktopAccess"
   alarm_action_arns = [
   data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
-  period    = "60"
-  threshold = "0"
-  statistic = "Sum"
+  evaluation_periods  = "1"
+  period              = 60
+  threshold           = 0
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
 }

--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -230,11 +230,11 @@ module "cleanup_lambda" {
 module "orchestration_service_failed_to_destroy_alarm" {
   source = "dwp/metric-filter-alarm/aws"
 
-  log_group_name    = module.ecs-fargate-task-definition.log_group
-  metric_namespace  = "/app/${var.name_prefix}"
-  pattern           = "{ $.message = \"Failed to destroy*\"}"
-  alarm_name        = "FailedToDestroy"
-  alarm_action_arns = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
+  log_group_name      = module.ecs-fargate-task-definition.log_group
+  metric_namespace    = "/app/${var.name_prefix}"
+  pattern             = "{ $.message = \"Failed to destroy*\"}"
+  alarm_name          = "FailedToDestroy"
+  alarm_action_arns   = [data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn]
   evaluation_periods  = "1"
   period              = 60
   threshold           = 0

--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -231,7 +231,7 @@ module "orchestration_service_failed_to_destroy_alarm" {
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.5"
 
-  log_group_name      = module.ecs-fargate-task-definition.log_group
+  log_group_name      = module.ecs-fargate-task-definition.log_group.name
   metric_namespace    = "/app/${var.name_prefix}"
   pattern             = "{ $.message = \"Failed to destroy*\"}"
   alarm_name          = "Orchestration Service Failed To Destroy Resources"

--- a/terraform/modules/fargate-task-definition/outputs.tf
+++ b/terraform/modules/fargate-task-definition/outputs.tf
@@ -24,5 +24,8 @@ output "container_name" {
 
 output "log_group" {
   description = "Name of the log group for OS"
-  value       = aws_cloudwatch_log_group.lamda_logs.name
+  value = {
+    name = aws_cloudwatch_log_group.lamda_logs.name
+    arn  = aws_cloudwatch_log_group.lamda_logs.arn
+  }
 }

--- a/terraform/modules/fargate-task-definition/outputs.tf
+++ b/terraform/modules/fargate-task-definition/outputs.tf
@@ -21,3 +21,8 @@ output "container_name" {
   description = "Name of the container"
   value       = var.container_name
 }
+
+output "log_group" {
+  description = "Name of the log group for OS"
+  value       = aws_cloudwatch_log_group.lamda_logs.name
+}

--- a/terraform/modules/fargate-task-definition/outputs.tf
+++ b/terraform/modules/fargate-task-definition/outputs.tf
@@ -23,7 +23,7 @@ output "container_name" {
 }
 
 output "log_group" {
-  description = "Name of the log group for OS"
+  description = "Orchestration Service Task log group attributes"
   value = {
     name = aws_cloudwatch_log_group.lamda_logs.name
     arn  = aws_cloudwatch_log_group.lamda_logs.arn


### PR DESCRIPTION
* Create cloudwatch log metric filter
* Create alarm when metric threshold is hit
* Send alert to SNS topic
* Triggers lambda to send slack notification


module documentation - https://registry.terraform.io/modules/dwp/metric-filter-alarm/aws/1.1.5
examples - https://github.ucds.io/dip/aws-ingestion/blob/master/kafka_to_hbase_monitoring.tf#L59...L92