### PR TITLE
[DW-4323] Restrict IAM policy further

### DIFF
--- a/terraform/modules/fargate-task-definition/iam.tf
+++ b/terraform/modules/fargate-task-definition/iam.tf
@@ -57,8 +57,8 @@ data "aws_iam_policy_document" "task_role" {
     ]
     resources = ["*"]
     condition {
-      test = "ArnEquals"
-      values = ["arn:aws:ecs:eu-west-2:${var.account}:cluster/orchestration-service-user-host"]
+      test     = "ArnEquals"
+      values   = ["arn:aws:ecs:eu-west-2:${var.account}:cluster/orchestration-service-user-host"]
       variable = "ecs:cluster"
     }
   }

--- a/terraform/modules/fargate-task-definition/iam.tf
+++ b/terraform/modules/fargate-task-definition/iam.tf
@@ -14,16 +14,29 @@ data "aws_iam_policy_document" "ecs-tasks" {
 
 data "aws_iam_policy_document" "task_role" {
   statement {
-    sid = "AllowDynamoDBActionsOnUserTable"
+    sid = "AllowDynamoDBCreateTable"
     actions = [
       "dynamodb:CreateTable",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid = "AllowDynamoDbListALlTables"
+    actions = [
+      "dynamodb:ListTables",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid = "AllowDynamoDBActionsOnUserTable"
+    actions = [
       "dynamodb:DeleteItem",
       "dynamodb:GetItem",
       "dynamodb:ListTables",
       "dynamodb:PutItem",
       "dynamodb:UpdateItem",
     ]
-    resources = ["*"]
+    resources = ["arn:aws:dynamodb:eu-west-2:${var.account}:table/orchestration_service_user_tasks"]
   }
   statement {
     sid = "AllowEC2DescribeImage"
@@ -39,11 +52,23 @@ data "aws_iam_policy_document" "task_role" {
       "ecs:CreateService",
       "ecs:DeleteService",
       "ecs:DescribeServices",
-      "ecs:DescribeTaskDefinition",
-      "ecs:RegisterTaskDefinition",
       "ecs:RunTask",
       "ecs:UpdateService",
     ]
+    resources = ["*"]
+    condition {
+      test = "ArnEquals"
+      values = ["arn:aws:ecs:eu-west-2:${var.account}:cluster/orchestration-service-user-host"]
+      variable = "ecs:cluster"
+    }
+  }
+  statement {
+    sid = "ECSTaskDefinitionsActions"
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+    ]
+    // Doesn't accept conditions or resource limitations
     resources = ["*"]
   }
   statement {
@@ -58,6 +83,7 @@ data "aws_iam_policy_document" "task_role" {
       "elasticloadbalancing:DescribeRules",
       "elasticloadbalancing:DescribeTargetGroupAttributes",
     ]
+    // Unable to restrict conditions or resources effectively
     resources = ["*"]
   }
   statement {
@@ -70,6 +96,13 @@ data "aws_iam_policy_document" "task_role" {
       "iam:DeletePolicy",
       "iam:DeleteRole",
       "iam:PassRole",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowKMSKeyDescribeForUserContainer"
+    actions = [
       "kms:DescribeKey",
     ]
     resources = ["*"]

--- a/terraform/modules/fargate-task-definition/iam.tf
+++ b/terraform/modules/fargate-task-definition/iam.tf
@@ -32,7 +32,6 @@ data "aws_iam_policy_document" "task_role" {
     actions = [
       "dynamodb:DeleteItem",
       "dynamodb:GetItem",
-      "dynamodb:ListTables",
       "dynamodb:PutItem",
       "dynamodb:UpdateItem",
     ]

--- a/terraform/modules/fargate-task-definition/iam.tf
+++ b/terraform/modules/fargate-task-definition/iam.tf
@@ -86,19 +86,27 @@ data "aws_iam_policy_document" "task_role" {
     resources = ["*"]
   }
   statement {
-    sid = "AllowIAMActionsForUserContainerRoles"
+    sid = "AllowIAMPolicyActionsForUserContainerRoles"
+    actions = [
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account}:policy/analytical-*-iamPolicyTaskArn",
+      "arn:aws:iam::${var.account}:policy/analytical-*-iamPolicyUserArn",
+    ]
+  }
+  statement {
+    sid = "AllowIAMRoleActionsForUserContainerRoles"
     actions = [
       "iam:AttachRolePolicy",
-      "iam:CreatePolicy",
       "iam:CreateRole",
       "iam:DetachRolePolicy",
-      "iam:DeletePolicy",
       "iam:DeleteRole",
       "iam:PassRole",
     ]
-    resources = ["*"]
+    resources = ["arn:aws:iam::${var.account}:role/orchestration-service-user-*"]
   }
-
   statement {
     sid = "AllowKMSKeyDescribeForUserContainer"
     actions = [


### PR DESCRIPTION
* Add conditions to ECS actions so they can only be performed in specific cluster
* Add resource limitation to DynamoDB actions so they can only be performed on user table
* Split actions that were in same statement