### PR TITLE
DW-4442 Fix chrome container healthcheck

### DIFF
--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
@@ -152,7 +152,7 @@ class TaskDeploymentService {
                 .condition(ContainerCondition.HEALTHY)
                 .build()
         val headlessChromeHealthCheck = HealthCheck.builder()
-                .command("CMD", "nc", "-z", "127.0.0.1", "5900")
+                .command("CMD", "supervisorctl", "status", "|", "awk", "'BEGIN {c=0} $2 == \"RUNNING\" {c++} END {exit c != 3}")
                 .interval(12)
                 .timeout(12)
                 .startPeriod(20)


### PR DESCRIPTION
It seems that using netcat to check port 5900 severs the connection between guacd and x11vnc, causing the guacamole session to be dropped whenever the healthcheck is performed. 

This PR changes the healthcheck to use supervisorctl to check that all required services are running.