### PR TITLE
adding absolute path to file in unzip

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -84,7 +84,8 @@ jobs:
       - name: move-file-for-publish
         run: |
           mkdir -p build/libs
-          unzip libs.zip -d build/libs
+          cp ${GITHUB_WORKSPACE}/*.jar build/libs/
+        if: ${{ success() }}
 
       - name: Get release version
         id: get_version


### PR DESCRIPTION
* Copying downloaded .jar files from artifact to `build/libs` to allow the publish to docker job to run on master