### PR TITLE
[DW-4674] Set max/min ASG values for production and non-prod

### DIFF
--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -182,8 +182,8 @@ module "ecs-user-host" {
   source = "../../modules/ecs-user"
   ami_id = data.aws_ami.hardened.id
   auto_scaling = {
-    max_size              = 1
-    min_size              = 1
+    max_size              = local.environment == "production" ? 6 : 3
+    min_size              = local.environment == "production" ? 3 : 1
     max_instance_lifetime = 604800
   }
   common_tags        = merge(local.common_tags, { Name = "${var.name_prefix}-user-host" })


### PR DESCRIPTION
To ensure we have capacity for our 10 new users, we need to increase the size of our ECS cluster in production

* Set max size to 6 in production and 3 in non-prod
* Set min size to 3 in production and 1 in non-prod