### PR TITLE
[DW-XXXX] Change instance type to m5 for user host

### DIFF
--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -187,7 +187,7 @@ module "ecs-user-host" {
     max_instance_lifetime = 604800
   }
   common_tags        = merge(local.common_tags, { Name = "${var.name_prefix}-user-host" })
-  instance_type      = "t3.2xlarge"
+  instance_type      = "m5.2xlarge"
   name_prefix        = "${var.name_prefix}-user-host"
   frontend_alb_sg_id = data.terraform_remote_state.aws_analytical_env_infra.outputs.alb_sg.id
   guacamole_port     = local.guacamole_port


### PR DESCRIPTION
* To allow for trunked ENI (increased eni counts in ECS) we need to be using a supported instance type