### PR TITLE
[DW-4699] Add taint job for User Host ASG

### DIFF
--- a/aviator.yml
+++ b/aviator.yml
@@ -9,6 +9,8 @@ spruce:
     except:
     - management-dev.yml.j2
     - management.yml.j2
+  - with_in: ci/jobs/taint/
+    regexp: ".*yml"
   to: aviator_pipeline.yml
 fly:
   name: orchestration-service

--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -9,3 +9,10 @@ groups:
 - name: pull-request
   jobs:
   - orchestration-service-pr
+- name: roll-os-user
+  jobs:
+    - taint-dev
+    - taint-qa
+    - taint-int
+    - taint-preprod
+    - taint-prod

--- a/ci/jobs/taint/dev.yml
+++ b/ci/jobs/taint/dev.yml
@@ -1,0 +1,26 @@
+jobs:
+  - name: taint-dev
+    plan:
+      - get: orchestration-service
+        trigger: false
+      - .: (( inject meta.plan.terraform-bootstrap ))
+        params:
+          DEPLOY_PATH: app
+
+      - .: (( inject meta.plan.terraform-taint ))
+        params:
+          DEPLOY_PATH: app
+
+      - .: (( inject meta.plan.terraform-apply ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+
+      - .: (( inject meta.plan.terraform-plan ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app

--- a/ci/jobs/taint/int.yml
+++ b/ci/jobs/taint/int.yml
@@ -1,0 +1,29 @@
+jobs:
+  - name: taint-int
+    plan:
+      - get: orchestration-service
+        trigger: false
+      - .: (( inject meta.plan.terraform-bootstrap ))
+        params:
+          DEPLOY_PATH: app
+
+      - .: (( inject meta.plan.terraform-taint ))
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'integration'
+
+      - .: (( inject meta.plan.terraform-apply ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'integration'
+
+      - .: (( inject meta.plan.terraform-plan ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'integration'

--- a/ci/jobs/taint/preprod.yml
+++ b/ci/jobs/taint/preprod.yml
@@ -1,0 +1,29 @@
+jobs:
+  - name: taint-preprod
+    plan:
+      - get: orchestration-service
+        trigger: false
+      - .: (( inject meta.plan.terraform-bootstrap ))
+        params:
+          DEPLOY_PATH: app
+
+      - .: (( inject meta.plan.terraform-taint ))
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'preprod'
+
+      - .: (( inject meta.plan.terraform-apply ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'preprod'
+
+      - .: (( inject meta.plan.terraform-plan ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'preprod'

--- a/ci/jobs/taint/prod.yml
+++ b/ci/jobs/taint/prod.yml
@@ -1,0 +1,31 @@
+jobs:
+  - name: taint-prod
+    plan:
+      - get: orchestration-service
+        trigger: false
+
+      - .: (( inject meta.plan.terraform-bootstrap ))
+        params:
+          DEPLOY_PATH: app
+
+      - .: (( inject meta.plan.terraform-taint ))
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'production'
+
+      - .: (( inject meta.plan.terraform-apply ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'production'
+
+
+      - .: (( inject meta.plan.terraform-plan ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'production'

--- a/ci/jobs/taint/qa.yml
+++ b/ci/jobs/taint/qa.yml
@@ -1,0 +1,29 @@
+jobs:
+  - name: taint-qa
+    plan:
+      - get: orchestration-service
+        trigger: false
+      - .: (( inject meta.plan.terraform-bootstrap ))
+        params:
+          DEPLOY_PATH: app
+
+      - .: (( inject meta.plan.terraform-taint ))
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'qa'
+
+      - .: (( inject meta.plan.terraform-apply ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'qa'
+
+      - .: (( inject meta.plan.terraform-plan ))
+        config:
+          run:
+            dir: 'orchestration-service/terraform/deploy/app'
+        params:
+          DEPLOY_PATH: app
+          TF_WORKSPACE: 'qa'

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -97,3 +97,21 @@ meta:
         - name: terraform-config
         outputs:
         - name: terraform-output
+
+    terraform-taint:
+      task: terraform-taint
+      .: (( inject meta.plan.terraform-common-config ))
+      config:
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cp terraform-config/terraform.tf .
+              cp terraform-config/terraform.tfvars .
+              terraform workspace show
+              terraform init
+              terraform taint "module.ecs-user-host.aws_autoscaling_group.user_host"
+        inputs:
+          - name: aws-analytical-env
+          - name: terraform-config

--- a/terraform/modules/ecs-user/asg.tf
+++ b/terraform/modules/ecs-user/asg.tf
@@ -21,10 +21,6 @@ resource "aws_autoscaling_group" "user_host" {
       propagate_at_launch = true
     }
   }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 data "template_cloudinit_config" "ecs_config" {


### PR DESCRIPTION
* In order to taint the ASG then recreate it, we have to turn off the flag `create before destoy: true` as it attempts to recreate the ASG before destroying the old one. This fails of course, due to duplicate ASGs with the same name. The flag seems redundant for this resource anyway. 

* The jobs can be removed after the process is complete if necessary - or we can keep them for any further use cases that may arise. 