### PR TITLE
[]DW-4699] Scale down cluster overnight

### DIFF
--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -183,7 +183,7 @@ module "ecs-user-host" {
   ami_id = data.aws_ami.hardened.id
   auto_scaling = {
     max_size              = local.environment == "production" ? 6 : 3
-    min_size              = local.environment == "production" ? 3 : 1
+    min_size              = 0
     max_instance_lifetime = 604800
   }
   common_tags        = merge(local.common_tags, { Name = "${var.name_prefix}-user-host" })

--- a/terraform/deploy/app/orchestration_service.tf
+++ b/terraform/deploy/app/orchestration_service.tf
@@ -183,7 +183,7 @@ module "ecs-user-host" {
   ami_id = data.aws_ami.hardened.id
   auto_scaling = {
     max_size              = local.environment == "production" ? 6 : 3
-    min_size              = 0
+    min_size              = local.environment == "production" ? 3 : 1
     max_instance_lifetime = 604800
   }
   common_tags        = merge(local.common_tags, { Name = "${var.name_prefix}-user-host" })

--- a/terraform/modules/cleanup-lambda/cloudwatch_event_trigger.tf
+++ b/terraform/modules/cleanup-lambda/cloudwatch_event_trigger.tf
@@ -1,11 +1,11 @@
-resource "aws_cloudwatch_event_rule" "fire_at_three_seventeen" {
+resource "aws_cloudwatch_event_rule" "fire_at_midnight" {
   name                = "between-three-and-four"
   description         = "Fires every day at 03:17am"
   schedule_expression = "cron(17 0 * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "cleanup_lambda_target" {
-  rule      = aws_cloudwatch_event_rule.fire_at_three_seventeen.name
+  rule      = aws_cloudwatch_event_rule.fire_at_midnight.name
   target_id = "lambda"
   arn       = aws_lambda_function.cleanup_lambda.arn
 }
@@ -15,7 +15,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_cleanup_lambda" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.cleanup_lambda.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.fire_at_three_seventeen.arn
+  source_arn    = aws_cloudwatch_event_rule.fire_at_midnight.arn
 }
 
 resource "aws_cloudwatch_log_group" "cleanup_lambda_logs" {

--- a/terraform/modules/cleanup-lambda/cloudwatch_event_trigger.tf
+++ b/terraform/modules/cleanup-lambda/cloudwatch_event_trigger.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_event_rule" "fire_at_three_seventeen" {
   name                = "between-three-and-four"
   description         = "Fires every day at 03:17am"
-  schedule_expression = "cron(17 3 * * ? *)"
+  schedule_expression = "cron(17 0 * * ? *)"
 }
 
 resource "aws_cloudwatch_event_target" "cleanup_lambda_target" {

--- a/terraform/modules/ecs-user/asg.tf
+++ b/terraform/modules/ecs-user/asg.tf
@@ -27,6 +27,23 @@ resource "aws_autoscaling_group" "user_host" {
   }
 }
 
+resource "aws_autoscaling_schedule" "scale_up_6am" {
+  scheduled_action_name  = "scale_up_6am"
+  min_size               = var.auto_scaling.min_size
+  desired_capacity       = var.auto_scaling.min_size
+  max_size               = var.auto_scaling.max_size
+  recurrence             = "5 6 * * * "
+  autoscaling_group_name = aws_autoscaling_group.user_host.name
+}
+
+resource "aws_autoscaling_schedule" "scale_down_midnight" {
+  scheduled_action_name  = "scale_down_midnight"
+  min_size               = 0
+  max_size               = var.auto_scaling.max_size
+  recurrence             = "5 0 * * * "
+  autoscaling_group_name = aws_autoscaling_group.user_host.name
+}
+
 data "template_cloudinit_config" "ecs_config" {
   gzip          = true
   base64_encode = true


### PR DESCRIPTION
* Two benefits - cost saving, and allows changes to the launch configuration to take effect during down-time (e.g. instance type change)
* After the ASG reaches zero overnight, any new instances created again when it scales up will have the changes applied.