### PR TITLE
[DW-4571] Prevent users from navigating away from localhost:8000

### DIFF
--- a/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
+++ b/src/main/kotlin/uk/gov/dwp/dataworks/services/TaskDeploymentService.kt
@@ -179,6 +179,7 @@ class TaskDeploymentService {
                 .environment(pairsToKeyValuePairs(
                         "VNC_OPTS" to "-rfbport 5900 -xkb -noxrecord -noxfixes -noxdamage -display :1 -nopw -wait 5 -noclipboard",
                         "CHROME_OPTS" to arrayOf(
+                                "--host-rules='MAP * localhost:8000'",
                                 "--no-sandbox",
                                 "--window-position=0,0",
                                 "--force-device-scale-factor=1",


### PR DESCRIPTION
* redirect all connections to localhost:8000 to prevent users from navigating away from jupyterhub front end