### PR TITLE
undo new package install mentioned in DW-6956

### DIFF
--- a/terraform/deploy/app/variables.tf
+++ b/terraform/deploy/app/variables.tf
@@ -328,7 +328,7 @@ variable "component_tags" {
     }
     production = {
       hue             = "0.0.102"
-      rstudio_oss     = "0.0.52"
+      rstudio_oss     = "0.0.49"
       jupyter_hub     = "0.0.66"
       headless_chrome = "0.0.15"
       guacd           = "0.0.21"


### PR DESCRIPTION
It looks like the `install.packages()` is ignoring some packages during install and failing to report them as `unable to install`. 
So reverting to the last working image - ie., pre-DW-6956